### PR TITLE
Add missing transport fuell cell and fossil

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -54,7 +54,7 @@ sector:
     # 2040: 0.1
     # 2050: 0.15
   land_transport_electric_share:
-    0.85 # 1 means all EVs
+    0.10 # 1 means all EVs
     # 2020: 0
     # 2030: 0.25
     # 2040: 0.6

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -809,8 +809,7 @@ def add_land_transport(n, costs):
             suffix=" land transport fuel cell",
             bus=nodes + " H2",
             carrier="land transport fuel cell",
-            p_set=fuel_cell_share / options["transport_fuel_cell_efficiency"] *
-            transport[nodes],
+            p_set=fuel_cell_share / options["transport_fuel_cell_efficiency"] * transport[nodes],
         )
 
     if ice_share > 0:
@@ -906,9 +905,9 @@ if __name__ == "__main__":
     # Get the data required for land transport
     nodal_energy_totals = pd.read_csv(snakemake.input.nodal_energy_totals,
                                       index_col=0)
-    transport = pd.read_csv(snakemake.input.transport, index_col=0)
-    avail_profile = pd.read_csv(snakemake.input.avail_profile, index_col=0)
-    dsm_profile = pd.read_csv(snakemake.input.dsm_profile, index_col=0)
+    transport = pd.read_csv(snakemake.input.transport, index_col=0, parse_dates=True)
+    avail_profile = pd.read_csv(snakemake.input.avail_profile, index_col=0, parse_dates=True)
+    dsm_profile = pd.read_csv(snakemake.input.dsm_profile, index_col=0, parse_dates=True)
     nodal_transport_data = pd.read_csv(snakemake.input.nodal_transport_data,
                                        index_col=0)
 


### PR DESCRIPTION
Land transport fossil was not added due to config settings. Error was due to reading of csv files, which did not parse the datetimeindex correctly. Now the the datetimeindex is set correctly due to "parse_dates=True" options in pd.read_csv(). Resolves two tasks in #37.