### PR TITLE
Fix snakemake

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -10,8 +10,8 @@ CDIR = config['costs_dir']
 
 wildcard_constraints:
     lv="[a-z0-9\.]+",
-    simpl="[a-zA-Z0-9]*",
-    clusters="[0-9]+m?",
+    simpl="[a-zA-Z0-9]*|all",
+    clusters="[0-9]+m?|all",
     opts="[-+a-zA-Z0-9]*",
     sector_opts="[-+a-zA-Z0-9\.\s]*"
 
@@ -54,27 +54,26 @@ rule prepare_transport_data:
         transport_name='resources/transport_data.csv',
         clustered_pop_layout="resources/pop_layout_elec_s{simpl}_{clusters}.csv",
         # This is probably still dummy data, investigate and use real data TODO
-        temp_air_total="resources/temp_air_total_elec_s{simpl}_37.nc",
+        temp_air_total="resources/temp_air_total_elec_s{simpl}_{clusters}.nc",
 
     output: 
-        nodal_energy_totals='resources/nodal_energy_totals.csv',
-        transport='resources/transport.csv',
-        avail_profile='resources/avail_profile.csv',
-        dsm_profile='resources/dsm_profile.csv',
-        nodal_transport_data='resources/nodal_transport_data.csv',
+        # nodal_energy_totals='resources/nodal_energy_totals.csv',
+        # transport='resources/transport.csv',
+        # avail_profile='resources/avail_profile.csv',
+        # dsm_profile='resources/dsm_profile.csv',
+        # nodal_transport_data='resources/nodal_transport_data.csv',
+        dummy_wildcard="resources/dummy{simpl}_{clusters}.nc"
 
     script: "scripts/prepare_transport_data.py"
 
 rule calculate_dummy_pop_layout:
     input:
-        network='networks/elec_s{simpl}_{clusters}.nc',
-
+        network='networks/elec_s{simpl}_37.nc',  # fixed number of clusters
         # Get pop layouts from Europe (update to Morocco/Africa layout)
-        clustered_pop_layout="resources/pop_layout_elec_s{simpl}_37.csv",
+        clustered_pop_layout="resources/pop_layout_elec_s{simpl}_37.csv",  # fixed number of clusters
         #simplified_pop_layout="resources/pop_layout_elec_s{simpl}.csv",
 
-    output: clustered_pop_layout_dummy="resources/pop_layout_elec_s{simpl}_dummy.csv",
-
+    output: clustered_pop_layout_dummy="resources/pop_layout_elec_s{simpl}_37.csv",  # fixed number of clusters
     script: "scripts/calculate_dummy_pop_layout.py" 
 
 rule build_population_layouts:

--- a/Snakefile
+++ b/Snakefile
@@ -8,7 +8,12 @@ SDIR = config['summary_dir'] + '/' + config['run']
 RDIR = config['results_dir'] + config['run']
 CDIR = config['costs_dir']
 
-
+wildcard_constraints:
+    lv="[a-z0-9\.]+",
+    simpl="[a-zA-Z0-9]*",
+    clusters="[0-9]+m?",
+    opts="[-+a-zA-Z0-9]*",
+    sector_opts="[-+a-zA-Z0-9\.\s]*"
 
 rule prepare_sector_networks:
     input:
@@ -99,40 +104,39 @@ rule build_clustered_population_layouts:
     
     
 rule build_temperature_profiles:
-        input:
-            pop_layout_total="resources/pop_layout_total.nc",
-            pop_layout_urban="resources/pop_layout_urban.nc",
-            pop_layout_rural="resources/pop_layout_rural.nc",
-            regions_onshore="resources/regions_onshore_elec_s{simpl}_{clusters}.geojson"
-        output:
-            temp_soil_total="resources/temp_soil_total_elec_s{simpl}_{clusters}.nc",
-            temp_soil_rural="resources/temp_soil_rural_elec_s{simpl}_{clusters}.nc",
-            temp_soil_urban="resources/temp_soil_urban_elec_s{simpl}_{clusters}.nc",
-            temp_air_total="resources/temp_air_total_elec_s{simpl}_{clusters}.nc",
-            temp_air_rural="resources/temp_air_rural_elec_s{simpl}_{clusters}.nc",
-            temp_air_urban="resources/temp_air_urban_elec_s{simpl}_{clusters}.nc"
-        resources: mem_mb=20000
-        benchmark: "benchmarks/build_temperature_profiles/s{simpl}_{clusters}"
-        script: "scripts/build_temperature_profiles.py"
+    input:
+        pop_layout_total="resources/pop_layout_total.nc",
+        pop_layout_urban="resources/pop_layout_urban.nc",
+        pop_layout_rural="resources/pop_layout_rural.nc",
+        regions_onshore="resources/regions_onshore_elec_s{simpl}_{clusters}.geojson"
+    output:
+        temp_soil_total="resources/temp_soil_total_elec_s{simpl}_{clusters}.nc",
+        temp_soil_rural="resources/temp_soil_rural_elec_s{simpl}_{clusters}.nc",
+        temp_soil_urban="resources/temp_soil_urban_elec_s{simpl}_{clusters}.nc",
+        temp_air_total="resources/temp_air_total_elec_s{simpl}_{clusters}.nc",
+        temp_air_rural="resources/temp_air_rural_elec_s{simpl}_{clusters}.nc",
+        temp_air_urban="resources/temp_air_urban_elec_s{simpl}_{clusters}.nc"
+    resources: mem_mb=20000
+    benchmark: "benchmarks/build_temperature_profiles/s{simpl}_{clusters}"
+    script: "scripts/build_temperature_profiles.py"
 
     
 rule solve_network:
-        input:
-            overrides="data/override_component_attrs",
-            network=RDIR + "/prenetworks/elec_s{simpl}_{clusters}.nc",
-            costs=CDIR + "costs_{planning_horizons}.csv",
-            config=SDIR + '/configs/config.yaml'
-            
-        output: RDIR + "/postnetworks/elec_s{simpl}_{clusters}_{planning_horizons}.nc"
-        shadow: "shallow"
-        log:
-            solver=RDIR + "/logs/elec_s{simpl}_{clusters}_{planning_horizons}_solver.log",
-            python=RDIR + "/logs/elec_s{simpl}_{clusters}_{planning_horizons}_python.log",
-            memory=RDIR + "/logs/elec_s{simpl}_{clusters}_{planning_horizons}_memory.log"
-        threads: 4
-        resources: mem_mb=config['solving']['mem']
-        benchmark: RDIR + "/benchmarks/solve_network/elec_s{simpl}_{clusters}_{planning_horizons}"
-        script: "scripts/solve_network.py"
+    input:
+        overrides="data/override_component_attrs",
+        network=RDIR + "/prenetworks/elec_s{simpl}_{clusters}.nc",
+        costs=CDIR + "costs_{planning_horizons}.csv",
+        config=SDIR + '/configs/config.yaml',
+    output: RDIR + "/postnetworks/elec_s{simpl}_{clusters}_{planning_horizons}.nc"
+    shadow: "shallow"
+    log:
+        solver=RDIR + "/logs/elec_s{simpl}_{clusters}_{planning_horizons}_solver.log",
+        python=RDIR + "/logs/elec_s{simpl}_{clusters}_{planning_horizons}_python.log",
+        memory=RDIR + "/logs/elec_s{simpl}_{clusters}_{planning_horizons}_memory.log",
+    threads: 4
+    resources: mem_mb=config['solving']['mem']
+    benchmark: RDIR + "/benchmarks/solve_network/elec_s{simpl}_{clusters}_{planning_horizons}"
+    script: "scripts/solve_network.py"
 
 rule make_summary:
     input:

--- a/Snakefile
+++ b/Snakefile
@@ -5,7 +5,7 @@ HTTP = HTTPRemoteProvider()
 configfile: "config.yaml"
 
 SDIR = config['summary_dir'] + '/' + config['run']
-RDIR = config['results_dir'] + config['run']
+RDIR = config['results_dir'] + '/' + config['run']
 CDIR = config['costs_dir']
 
 wildcard_constraints:


### PR DESCRIPTION
This PR fixes main problems with snakemake.

Regarding prepare_sector_networks, though, it is a temporary fix because it needs a better interaction; we could discuss that next thursday.
The final fix relates to structuring the architecture of the rules and script to avoid that wildcards are used in rule inputs without being used in the outputs, which was occurring in prepare_sector_networks.
To avoid that, currently, I simply commented the outputs and added a dummy output; after a discussion/comment/talk, I can accomodate it.

I add comments to clarify.