### PR TITLE
 Set value of population to thousands

### DIFF
--- a/scripts/build_population_layouts.py
+++ b/scripts/build_population_layouts.py
@@ -22,8 +22,10 @@ if __name__ == '__main__':
     grid_cells = cutout.grid_cells()
 
     # nuts3 has columns country, gdp, pop, geometry
-    # population is given in dimensions of 1e3=k
     nuts3 = gpd.read_file(snakemake.input.nuts3_shapes).set_index('GADM_ID')
+
+    # Set value of population to same dimension as in PyPSA-Eur-Sec, where the value is given in 1e3
+    nuts3['pop'] = nuts3['pop']/1000
 
     # Indicator matrix NUTS3 -> grid cells
     I = atlite.cutout.compute_indicatormatrix(nuts3.geometry, grid_cells)


### PR DESCRIPTION
See #45 for problem description and reason behind the value difference:
"The difference arises due to the input dataset. In PyPSA-Eur-Sec "nuts3_shapes.geojson" is used to get population data, the value of population is given in thousands. In PyPSA-Earth-Sec we use GADM shapes, which have the value in real numbers
https://github.com/PyPSA/pypsa-eur-sec/blob/b6cfcf6364e1037ce2bdad53504c8df7eb2b72b0/scripts/build_population_layouts.py#L22"
This PR sets the value to thousands to avoid future issues with the population values in other scripts.  Closes #45 