### PR TITLE
Enable spatial representation for biogas and biomass

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -72,7 +72,7 @@ industry:
   MWh_CH4_per_tMeOH: 10.25 # DECHEMA (2017), Table 14, page 65
   hotmaps_locate_missing: false
   reference_year: 2015
-  
+
 costs:
   lifetime: 25 #default lifetime
   # From a Lion Hirth paper, also reflects average of Noothout et al 2016

--- a/config.yaml
+++ b/config.yaml
@@ -73,7 +73,6 @@ industry:
   hotmaps_locate_missing: false
   reference_year: 2015
   
-  
 costs:
   lifetime: 25 #default lifetime
   # From a Lion Hirth paper, also reflects average of Noothout et al 2016
@@ -375,7 +374,6 @@ plotting:
     agriculture electricity: '#222222'
     solid biomass for industry co2 from atmosphere: '#654321'
     solid biomass for industry co2 to stored: '#654321'
-    solid biomass for industry CC: '#654321'
     gas for industry co2 to atmosphere: '#654321'
     gas for industry co2 to stored: '#654321'
     Fischer-Tropsch: '#44DD33'

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -401,7 +401,7 @@ def add_biomass(n, costs):
     n.add("Carrier", "biogas")
     n.add("Carrier", "solid biomass")
 
-    n.add("Bus", "Africa biogas", location="Africa", carrier="biogas")
+    n.madd("Bus", spatial.gas.biogas, location=spatial.biomass.locations, carrier="biogas")
 
     n.madd(
         "Bus",
@@ -410,10 +410,10 @@ def add_biomass(n, costs):
         carrier="solid biomass",
     )
 
-    n.add(
+    n.madd(
         "Store",
-        "Africa biogas",
-        bus="Africa biogas",
+        spatial.gas.biogas,
+        bus=spatial.gas.biogas,
         carrier="biogas",
         e_nom=biomass_potentials["biogas"].sum(),
         marginal_cost=costs.at["biogas", "fuel"],
@@ -430,11 +430,11 @@ def add_biomass(n, costs):
         e_initial=biomass_potentials_spatial["solid biomass"],
     )
 
-    n.add(
+    n.madd(
         "Link",
-        "biogas to gas",
-        bus0="Africa biogas",
-        bus1="Africa gas",
+        spatial.gas.biogas_to_gas,
+        bus0=spatial.gas.biogas, 
+        bus1=spatial.gas.nodes, 
         bus2="co2 atmosphere",
         carrier="biogas to gas",
         capital_cost=costs.loc["biogas upgrading", "fixed"],

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -178,17 +178,17 @@ def add_gas(n, costs):
     if options["gas_network"]:
         spatial.gas.nodes = nodes + " gas"
         spatial.gas.locations = nodes
-        # spatial.gas.biogas = nodes + " biogas"
+        spatial.gas.biogas = nodes + " biogas"
         spatial.gas.industry = nodes + " gas for industry"
         spatial.gas.industry_cc = nodes + " gas for industry CC"
-        # spatial.gas.biogas_to_gas = nodes + " biogas to gas"
+        spatial.gas.biogas_to_gas = nodes + " biogas to gas"
     else:
         spatial.gas.nodes = ["Africa gas"]
         spatial.gas.locations = ["Africa"]
-        # spatial.gas.biogas = ["Africa biogas"]
+        spatial.gas.biogas = ["Africa biogas"]
         spatial.gas.industry = ["gas for industry"]
         spatial.gas.industry_cc = ["gas for industry CC"]
-        # spatial.gas.biogas_to_gas = ["Africa biogas to gas"]
+        spatial.gas.biogas_to_gas = ["Africa biogas to gas"]
 
     spatial.gas.df = pd.DataFrame(vars(spatial.gas), index=nodes)
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
Changes the spatial representation depending on wether a network is enabled or not. 
E.g.  (“Africa gas” -> e.g. “spatial.gas.nodes”)

## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
