### PR TITLE
Include missing industry demand csv

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -111,7 +111,7 @@ rule prepare_transport_data:
 
 rule build_industrial_production_per_country_tomorrow:  #YES
     input:
-        industrial_production_per_country="resources/industrial_production_per_country.csv",
+        industrial_production_per_country="data/industrial_production_per_country.csv",
     output:
         industrial_production_per_country_tomorrow="resources/industrial_production_per_country_tomorrow_{planning_horizons}.csv",
     threads: 1
@@ -128,7 +128,7 @@ rule build_industry_demand:  #Yes
         industry_sector_ratios="data/industry_sector_ratios.csv",
         industrial_distribution_key="resources/industrial_distribution_key_elec_s{simpl}_{clusters}.csv",
         industrial_production_per_country_tomorrow="resources/industrial_production_per_country_tomorrow_{planning_horizons}.csv",
-        industrial_production_per_country="resources/industrial_production_per_country.csv",
+        industrial_production_per_country="data/industrial_production_per_country.csv",
     output:
         industrial_energy_demand_per_node="resources/industrial_energy_demand_per_node_elec_s{simpl}_{clusters}_{planning_horizons}.csv",
     threads: 1

--- a/Snakefile
+++ b/Snakefile
@@ -491,7 +491,7 @@ rule run_test:
     run:
         import yaml
 
-        with open("../pypsa-africa/test/config.test1.yaml") as file:
+        with open("../pypsa-africa/test/config.test1_sec.yaml") as file:
 
             config_pypsaearth = yaml.full_load(file)
             config_pypsaearth["electricity"]["extendable_carriers"]["Store"] = []

--- a/Snakefile
+++ b/Snakefile
@@ -491,7 +491,7 @@ rule run_test:
     run:
         import yaml
 
-        with open("../pypsa-africa/test/config.test1_sec.yaml") as file:
+        with open("../pypsa-africa/test/config.test1.yaml") as file:
 
             config_pypsaearth = yaml.full_load(file)
             config_pypsaearth["electricity"]["extendable_carriers"]["Store"] = []

--- a/config.pypsa-earth.yaml
+++ b/config.pypsa-earth.yaml
@@ -25,10 +25,10 @@ snapshots:
   inclusive: "left" # end is not inclusive
 
 enable:
-  retrieve_databundle: true  #  Recommended 'true', for the first run. Otherwise data might be missing.
-  download_osm_data: true  # If 'true', OpenStreetMap data will be downloaded for the above given countries
+  retrieve_databundle: false  #  Recommended 'true', for the first run. Otherwise data might be missing.
+  download_osm_data: false  # If 'true', OpenStreetMap data will be downloaded for the above given countries
   build_natura_raster: false  # If True, than an exclusion raster will be build
-  build_cutout: false
+  build_cutout: true
   # If "build_cutout" : true, then environmental data is extracted according to `snapshots` date range and `countries`
   # requires cds API key https://cds.climate.copernicus.eu/api-how-to
   # More information https://atlite.readthedocs.io/en/latest/introduction.html#datasets

--- a/config.yaml
+++ b/config.yaml
@@ -72,8 +72,7 @@ industry:
   MWh_CH4_per_tMeOH: 10.25 # DECHEMA (2017), Table 14, page 65
   hotmaps_locate_missing: false
   reference_year: 2015
-  
-  
+
 costs:
   lifetime: 25 #default lifetime
   # From a Lion Hirth paper, also reflects average of Noothout et al 2016
@@ -375,7 +374,6 @@ plotting:
     agriculture electricity: '#222222'
     solid biomass for industry co2 from atmosphere: '#654321'
     solid biomass for industry co2 to stored: '#654321'
-    solid biomass for industry CC: '#654321'
     gas for industry co2 to atmosphere: '#654321'
     gas for industry co2 to stored: '#654321'
     Fischer-Tropsch: '#44DD33'

--- a/data/industrial_production_per_country.csv
+++ b/data/industrial_production_per_country.csv
@@ -1,0 +1,3 @@
+kton/a,Electric arc,Integrated steelworks,Other chemicals,Pharmaceutical products etc.,Cement,Ceramics & other NMM,Glass production,Pulp production,Paper production,Printing and media reproduction,"Food, beverages and tobacco",Alumina production,Aluminium - primary production,Aluminium - secondary production,Other non-ferrous metals,Transport Equipment,Machinery Equipment,Textiles and leather,Wood and wood products,Other Industrial Sectors,Ammonia,HVC,Chlorine,Methanol
+DE,12622,30053.69,5227.35,749.06,33222.15,32272.49,7432.8,2554,22608,1464.46,33929.7,1453.2,530,563.91,2778.69,101293.31,164889.37,7493.39,7827.96,31072.79,3035.71,17230.14,3174.32,497.02
+MA,0,1,8.79,0,0,0,0,0,0,12.13,51.35,0,0,0,0,13.39,126.24,23.44,0,91.61,0,0,0,0

--- a/data/industrial_production_per_country.csv
+++ b/data/industrial_production_per_country.csv
@@ -1,3 +1,5 @@
 kton/a,Electric arc,Integrated steelworks,Other chemicals,Pharmaceutical products etc.,Cement,Ceramics & other NMM,Glass production,Pulp production,Paper production,Printing and media reproduction,"Food, beverages and tobacco",Alumina production,Aluminium - primary production,Aluminium - secondary production,Other non-ferrous metals,Transport Equipment,Machinery Equipment,Textiles and leather,Wood and wood products,Other Industrial Sectors,Ammonia,HVC,Chlorine,Methanol
 DE,12622,30053.69,5227.35,749.06,33222.15,32272.49,7432.8,2554,22608,1464.46,33929.7,1453.2,530,563.91,2778.69,101293.31,164889.37,7493.39,7827.96,31072.79,3035.71,17230.14,3174.32,497.02
 MA,0,1,8.79,0,0,0,0,0,0,12.13,51.35,0,0,0,0,13.39,126.24,23.44,0,91.61,0,0,0,0
+NG,0,1,8.79,0,0,0,0,0,0,12.13,51.35,0,0,0,0,13.39,126.24,23.44,0,91.61,0,0,0,0
+BJ,0,1,8.79,0,0,0,0,0,0,12.13,51.35,0,0,0,0,13.39,126.24,23.44,0,91.61,0,0,0,0

--- a/scripts/build_industrial_production_tomorrow.py
+++ b/scripts/build_industrial_production_tomorrow.py
@@ -106,9 +106,7 @@ if __name__ == "__main__":
 
     production = pd.read_csv(
         snakemake.input.industrial_production_per_country, index_col=0
-    ).filter(
-        ["MA", "BJ", "NG"], axis=0
-    )  # .filter(config["countries"], axis=0)
+    ).filter(config["countries"], axis=0)
 
     prod_tomorrow = industry_prod_tomorrow(production)
 

--- a/scripts/build_industrial_production_tomorrow.py
+++ b/scripts/build_industrial_production_tomorrow.py
@@ -106,7 +106,8 @@ if __name__ == "__main__":
 
     production = pd.read_csv(
         snakemake.input.industrial_production_per_country, index_col=0
-    ).filter(config["countries"], axis=0)
+    ).filter(['MA', 'BJ', 'NG'], axis=0) #.filter(config["countries"], axis=0)
+
 
     prod_tomorrow = industry_prod_tomorrow(production)
 

--- a/scripts/build_industrial_production_tomorrow.py
+++ b/scripts/build_industrial_production_tomorrow.py
@@ -106,8 +106,9 @@ if __name__ == "__main__":
 
     production = pd.read_csv(
         snakemake.input.industrial_production_per_country, index_col=0
-    ).filter(['MA', 'BJ', 'NG'], axis=0) #.filter(config["countries"], axis=0)
-
+    ).filter(
+        ["MA", "BJ", "NG"], axis=0
+    )  # .filter(config["countries"], axis=0)
 
     prod_tomorrow = industry_prod_tomorrow(production)
 

--- a/test/config.test1.yaml
+++ b/test/config.test1.yaml
@@ -24,6 +24,56 @@ scenario:
   sopts:
   - "7H"
 
+countries: ['MA']
+
+industry:
+  St_primary_fraction: 0.9 # fraction of steel produced via primary route versus secondary route (scrap+EAF); today fraction is 0.6
+    # 2020: 0.6
+    # 2025: 0.55
+    # 2030: 0.5
+    # 2035: 0.45
+    # 2040: 0.4
+    # 2045: 0.35
+    # 2050: 0.3
+  DRI_fraction: 0.5 # fraction of the primary route converted to DRI + EAF
+    # 2020: 0
+    # 2025: 0
+    # 2030: 0.05
+    # 2035: 0.2
+    # 2040: 0.4
+    # 2045: 0.7
+    # 2050: 1
+  H2_DRI: 1.7   #H2 consumption in Direct Reduced Iron (DRI),  MWh_H2,LHV/ton_Steel from 51kgH2/tSt in Vogl et al (2018) doi:10.1016/j.jclepro.2018.08.279
+  elec_DRI: 0.322   #electricity consumption in Direct Reduced Iron (DRI) shaft, MWh/tSt HYBRIT brochure https://ssabwebsitecdn.azureedge.net/-/media/hybrit/files/hybrit_brochure.pdf
+  Al_primary_fraction: 0.2 # fraction of aluminium produced via the primary route versus scrap; today fraction is 0.4
+    # 2020: 0.4
+    # 2025: 0.375
+    # 2030: 0.35
+    # 2035: 0.325
+    # 2040: 0.3
+    # 2045: 0.25
+    # 2050: 0.2
+  MWh_CH4_per_tNH3_SMR: 10.8 # 2012's demand from https://ec.europa.eu/docsroom/documents/4165/attachments/1/translations/en/renditions/pdf
+  MWh_elec_per_tNH3_SMR: 0.7 # same source, assuming 94-6% split methane-elec of total energy demand 11.5 MWh/tNH3
+  MWh_H2_per_tNH3_electrolysis: 6.5 # from https://doi.org/10.1016/j.joule.2018.04.017, around 0.197 tH2/tHN3 (>3/17 since some H2 lost and used for energy)
+  MWh_elec_per_tNH3_electrolysis: 1.17 # from https://doi.org/10.1016/j.joule.2018.04.017 Table 13 (air separation and HB)
+  NH3_process_emissions: 24.5 # in MtCO2/a from SMR for H2 production for NH3 from UNFCCC for 2015 for EU28
+  petrochemical_process_emissions: 25.5 # in MtCO2/a for petrochemical and other from UNFCCC for 2015 for EU28
+  HVC_primary_fraction: 1. # fraction of today's HVC produced via primary route
+  HVC_mechanical_recycling_fraction: 0. # fraction of today's HVC produced via mechanical recycling
+  HVC_chemical_recycling_fraction: 0. # fraction of today's HVC produced via chemical recycling
+  HVC_production_today: 52. # MtHVC/a from DECHEMA (2017), Figure 16, page 107; includes ethylene, propylene and BTX
+  MWh_elec_per_tHVC_mechanical_recycling: 0.547 # from SI of https://doi.org/10.1016/j.resconrec.2020.105010, Table S5, for HDPE, PP, PS, PET. LDPE would be 0.756.
+  MWh_elec_per_tHVC_chemical_recycling: 6.9 # Material Economics (2019), page 125; based on pyrolysis and electric steam cracking
+  chlorine_production_today: 9.58 # MtCl/a from DECHEMA (2017), Table 7, page 43
+  MWh_elec_per_tCl: 3.6 # DECHEMA (2017), Table 6, page 43
+  MWh_H2_per_tCl: -0.9372  # DECHEMA (2017), page 43; negative since hydrogen produced in chloralkali process
+  methanol_production_today: 1.5 # MtMeOH/a from DECHEMA (2017), page 62
+  MWh_elec_per_tMeOH: 0.167 # DECHEMA (2017), Table 14, page 65
+  MWh_CH4_per_tMeOH: 10.25 # DECHEMA (2017), Table 14, page 65
+  hotmaps_locate_missing: false
+  reference_year: 2015
+
 costs:
   lifetime: 25 #default lifetime
   # From a Lion Hirth paper, also reflects average of Noothout et al 2016


### PR DESCRIPTION
## Changes proposed in this Pull Request
The file `industrial_production_per_country.csv` was in the resource folder and hence not tracked, now it's in the data folder and the snakefile links are adjusted.

## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
